### PR TITLE
`handle_request` の送信元検証と未認証レプリケーション削除

### DIFF
--- a/src/protocol/operation.rs
+++ b/src/protocol/operation.rs
@@ -24,7 +24,8 @@ const RPC_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct Protocol<S, N>
 where
   S: Storage,
-  N: Network, {
+  N: Network,
+{
   /// Local node ID
   node_id: NodeId,
   /// Local node socket address
@@ -84,8 +85,17 @@ where
 
   /// Handle an incoming request
   pub async fn handle_request(&self, req: RequestMessage, from: SocketAddr) -> Result<()> {
-    let sender = req.sender().clone();
-    let is_new_contact = self.record_contact(&sender).await?;
+    let mut sender = req.sender().clone();
+    if sender.addr != from {
+      tracing::warn!(
+        sender_id = %sender.id,
+        claimed_addr = %sender.addr,
+        packet_source = %from,
+        "Received request with mismatched sender address; using packet source address"
+      );
+      sender.addr = from;
+    }
+    let _ = self.record_contact(&sender).await?;
 
     match req {
       RequestMessage::Ping { id, sender } => {
@@ -99,12 +109,6 @@ where
       }
       RequestMessage::FindValue { id, sender, key } => {
         self.handle_find_value(id, sender, key, from).await?;
-      }
-    }
-
-    if is_new_contact {
-      if let Err(err) = self.replicate_to_new_node(&sender).await {
-        tracing::debug!(target = %sender.id, ?err, "Failed to replicate data to new node");
       }
     }
 
@@ -801,37 +805,6 @@ where
             Ok(Err(e)) => tracing::warn!(node_id = %node.id, error = ?e, "Error storing on node"),
             Err(_) => tracing::warn!(node_id = %node.id, "Timeout storing on node"),
           }
-        }
-      }
-    }
-
-    Ok(())
-  }
-
-  async fn replicate_to_new_node(&self, node: &Node) -> Result<()> {
-    let keys = {
-      let storage = self.storage.read().await;
-      storage.keys()
-    };
-
-    for key in keys {
-      let should_store = {
-        let table = self.routing_table.read().await;
-        table.get_closest(&key, K).iter().any(|closest| closest.id == node.id)
-      };
-
-      if !should_store {
-        continue;
-      }
-
-      let value_opt = {
-        let mut storage = self.storage.write().await;
-        storage.get(&key).ok()
-      };
-
-      if let Some(value) = value_opt {
-        if let Err(err) = self.store(node, key.clone(), value).await {
-          tracing::debug!(target = %node.id, key = %key, ?err, "Replication store failed");
         }
       }
     }


### PR DESCRIPTION
### Motivation
- `handle_request` がリクエスト内の `sender` メタデータをそのまま信頼して新規コンタクト時に全キーをレプリケーションしていたため、送信元アドレス偽装で任意アドレスへのデータ送信およびハンドラの長時間ブロック（DoS/データ漏えい）が可能になっていた。

### Description
- `src/protocol/operation.rs` の `handle_request` で受信パケットの実際の送信元 `from` と `req.sender().addr` を比較し、不一致の場合は `from` を採用して警告を出すようにした（`sender.addr` を盲信しない）。
- 新規コンタクト検知後に即時に全キーを反復して `STORE` する自動レプリケーション呼び出しを削除した。
- 未使用になった `replicate_to_new_node` 関数を削除して、未認証経路によるデータ送信パスを取り除いた。 
- PING/STORE/FIND_NODE/FIND_VALUE の既存レスポンス処理は維持している。 

### Testing
- `cargo fmt && cargo build && cargo test -- --test-threads=1` を実行し、リポジトリ内のユニットおよび統合テストが全て成功していることを確認した（テストスイートはすべてパス）。
- `cargo +nightly fmt && cargo build && cargo test` は環境のツールチェーン取得で失敗したため実行不能であったが、通常ツールチェーンでのビルドとテストは成功している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af255c0700832d9dce5f7d640dab80)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RPC request handling and changes replication behavior, which could affect routing-table accuracy and data availability if other components relied on the removed implicit replication. The changes reduce spoofing/DoS risk by no longer trusting claimed sender metadata and by removing an unauthenticated data-send path.
> 
> **Overview**
> **Hardens inbound request handling.** `handle_request` now compares the request’s claimed `sender.addr` with the actual packet source `from`, logs a warning on mismatch, and uses the packet source address instead of trusting sender metadata.
> 
> **Removes unauthenticated replication side effects.** The “new contact” auto-replication triggered during request handling is deleted, along with the unused `replicate_to_new_node` helper, eliminating an implicit bulk `STORE` path on first contact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892b3219f8ab1e29863e15220010e441f66d9be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->